### PR TITLE
Added a 'virtualenv' command to setup.py to bootstrap venvs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,7 @@ target/
 .ipynb_checkpoints
 
 *.swp
+
+# virtualenv
+venv
 activate

--- a/README.md
+++ b/README.md
@@ -30,13 +30,12 @@ install this if `pip` isn't available on your system. For example, on Ubuntu
 you'll need to run `apt-get install python-virtualenv`.
 
 Create and activate a virtual environment for the cthulhu project using
-`virtualenv`. You can create your virtual environment anywhere you want, but I
-usually use `~/.venvs`.
+`virtualenv`.
 
 ```
 cd cthulhu
-virtualenv ~/.venvs/cthulhu
-source ~/.venvs/cthulhu/activate
+python setup.py virtualenv
+source activate
 python setup.py develop
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import os
 import subprocess
@@ -7,81 +8,109 @@ from setuptools import setup, find_packages, Command
 
 
 entry_points = {
-  'console_scripts': [
-    'cthulhu = cthulhu.bin.cthulhu:main',
-  ],
+    'console_scripts': [
+        'cthulhu = cthulhu.bin.cthulhu:main',
+    ],
 }
 
 
+class Venv(Command):
+    user_options = []
+
+    def initialize_options(self):
+        """Abstract method that is required to be overwritten"""
+
+    def finalize_options(self):
+        """Abstract method that is required to be overwritten"""
+
+    def run(self):
+        venv_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'venv', 'cthulhu')
+        venv_cmd = [
+            'virtualenv',
+            venv_path
+        ]
+        print('Creating virtual environment in ', venv_path)
+        subprocess.check_call(venv_cmd)
+        print('Linking `activate` to top level of project.\n')
+        print('To activate, simply run `source activate`.')
+        try:
+            os.symlink(
+                os.path.join(venv_path, 'bin', 'activate'),
+                os.path.join(os.path.dirname(os.path.abspath(__file__)), 'activate')
+            )
+        except OSError:
+            print('Unable to create symlink, you may have a stale symlink from a previous invocation.')
+
+
 class Pex(Command):
+    user_options = []
 
-  user_options = []
+    def initialize_options(self):
+        """Abstract method that is required to be overwritten"""
 
-  def initialize_options(self):
-    """Abstract method that is required to be overwritten"""
+    def finalize_options(self):
+        """Abstract method that is required to be overwritten"""
 
-  def finalize_options(self):
-    """Abstract method that is required to be overwritten"""
-
-  def run(self):
-    if not os.path.exists('dist/wheel-cache'):
-      print('You need to create dist/wheel-cache first! You\'ll need to run the following.')
-      print('  mkdir dist/wheel-cache')
-      print('  pip wheel -w dist/wheel-cache')
-      return
-    for entry in entry_points['console_scripts']:
-      name, call = tuple([_.strip() for _ in entry.split('=')])
-      print('Creating {0} as {1}'.format(name, call))
-      pex_cmd = [
-        'pex',
-        '--no-pypi',
-        '--repo=dist/wheel-cache',
-        '-o', 'build/bin/{0}'.format(name),
-        '-e', call,
-        '.',
-      ]
-      print('Running {0}'.format(' '.join(pex_cmd)))
-      subprocess.check_call(pex_cmd)
+    def run(self):
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+        if not os.path.exists('dist/wheel-cache'):
+            print(
+                'You need to create dist/wheel-cache first! You\'ll need to run the following.')
+            print('  mkdir -p dist/wheel-cache')
+            print('  pip wheel -w dist/wheel-cache')
+            return
+        for entry in entry_points['console_scripts']:
+            name, call = tuple([_.strip() for _ in entry.split('=')])
+            print('Creating {0} as {1}'.format(name, call))
+            pex_cmd = [
+                'pex',
+                '--no-pypi',
+                '--repo=dist/wheel-cache',
+                '-o', 'build/bin/{0}'.format(name),
+                '-e', call,
+                '.',
+            ]
+            print('Running {0}'.format(' '.join(pex_cmd)))
+            subprocess.check_call(pex_cmd)
 
 
 setup(
-  name='cthulhu',
-  version='0.0.1',
-  description="A distributed systems testing framework.",
-  author='Stephen Holsapple',
-  author_email='sholsapp@gmail.com',
-  url='https://github.com/sholsapp/gallocy',
-  license='Apache License, Version 2.0',
-  packages=find_packages(),
-  install_requires=[
-    # For compatibility with py2.6
-    'argparse',
-    'click',
-    'jinja2',
-    'netaddr',
-    'netifaces',
-    'pex',
-    'requests',
-    'tabulate',
-    'wheel',
-  ],
-  tests_require=[
-    'flake8',
-    'pytest',
-    'pytest-cov',
-  ],
-  entry_points=entry_points,
-  cmdclass={'pexify': Pex},
-  classifiers=[
-    'License :: OSI Approved :: Apache Software License',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.6',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: Implementation :: CPython',
-    'Programming Language :: Python :: Implementation :: PyPy',
-    'Topic :: Security :: Cryptography',
-    'Topic :: Software Development :: Libraries :: Python Modules',
-  ],
+    name='cthulhu',
+    version='0.0.1',
+    description="A distributed systems testing framework.",
+    author='Stephen Holsapple',
+    author_email='sholsapp@gmail.com',
+    url='https://github.com/sholsapp/gallocy',
+    license='Apache License, Version 2.0',
+    packages=find_packages(),
+    install_requires=[
+        "argparse",
+        "click",
+        "jinja2",
+        "netaddr",
+        "netifaces",
+        "pex",
+        "requests",
+        "tabulate",
+        "wheel",
+    ],
+    tests_require=[
+        'flake8',
+        'pytest',
+        'pytest-cov',
+    ],
+    entry_points=entry_points,
+    cmdclass={'pexify': Pex, 'virtualenv': Venv},
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Security :: Cryptography',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
 )


### PR DESCRIPTION
Also, only animals use 2 space python indents.

```
osx ~/src/cthulhu git:virtualenv_bootstrap ❯❯❯ python setup.py virtualenv
running virtualenv
Creating virtual environment in  /Users/lcarvalh/src/cthulhu/venv/cthulhu
New python executable in /Users/lcarvalh/src/cthulhu/venv/cthulhu/bin/python
Installing setuptools, pip, wheel...done.
Linking `activate` to top level of project.

To activate, simply run `source activate`.
osx ~/src/cthulhu git:virtualenv_bootstrap ❯❯❯ source activate
(cthulhu)osx ~/src/cthulhu git:virtualenv_bootstrap ❯❯❯ python setup.py install
running install
running bdist_egg
...
...
...
```
